### PR TITLE
Create the `.ssh` directory if it doesn't exist

### DIFF
--- a/suited.sh
+++ b/suited.sh
@@ -910,7 +910,7 @@ ERRORS=probably
 
 export IN_SUITED=1
 
-[ ! -f $HOME/.ssh/known_hosts ] && \
+[ ! -f $HOME/.ssh/known_hosts ] && mkdir -p $HOME/.ssh && chmod 700 $HOME/.ssh && \
     ssh-keyscan -t rsa github.com >$HOME/.ssh/known_hosts 2>/dev/null
 
 for file in "$@"; do


### PR DESCRIPTION
Hi Norm!

Just started using this and it's great, but I had an issue with a fresh computer where the `.ssh` directory didn't exist. (`suited.sh: line 914: .../.ssh/known_hosts: No such file or directory`).

I've tested this fix both on the fresh install and then running it again to check it's fine when the directory does exist.

Thanks!
Anna

-------
This line checks for the `known_hosts` file, but it assumes that the `.ssh` directory itself exists. On a fresh computer, this command failed.

This addition adds two more arguments to the expression to create the directory if it doesn't exist and give it the correct permissions. They fail silently so if they do already exist it will still have the desired effect.