### PR TITLE
Ignore more files in macOS defaults repos

### DIFF
--- a/setup/apply_defaults.sh
+++ b/setup/apply_defaults.sh
@@ -4,7 +4,8 @@ if [ -d $dir ]; then
     pushd $dir >/dev/null  # unnecessarily noisy
 
     for file in *; do
-        if [ "$file" != 'README.markdown' ]; then
+        if [ "$file" != "README.markdown" -a \
+          "$file" != "README.md" -a "$file" != "LICENCE" ]; then
             status "apply $file"
 
             for line in $( cat "$file" ); do


### PR DESCRIPTION
Some people (me) like to name `README`s with a `.md` extension rather than `.markdown`. And it's nice to apply licences to things.